### PR TITLE
Add CI actions on macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,17 +64,23 @@ jobs:
       matrix:
         os:
           - macos-14
+          - ubuntu-22.04
     env:
       build_dir: ${{ github.workspace }}/build
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install dependencies (macOS)
         run: brew install fmt postgresql cpp-gsl
+        if: matrix.os == 'macos-14'
+
+      - name: Install dependencies (Ubuntu)
+        run: sudo apt-get install libfmt-dev libpq-dev libsqlite3-dev
+        if: matrix.os == 'ubuntu-22.04'
 
       - name: Configure CMake
-        run: CXX=${{ env.compiler }} cmake -B ${{ env.build_dir }} -S ${{ github.workspace }} -DPFR_ORM_ASAN:BOOL=ON -DPFR_ORM_TEST:BOOL=ON -DPFR_ORM_USE_GSL_SPAN:BOOL=ON
+        run: cmake -B ${{ env.build_dir }} -S ${{ github.workspace }} -DPFR_ORM_ASAN:BOOL=ON -DPFR_ORM_TEST:BOOL=ON -DPFR_ORM_USE_GSL_SPAN:BOOL=ON
 
       - name: Build tests
         run: cmake --build ${{ env.build_dir }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.os == 'macos-14'
 
       - name: Install dependencies (Ubuntu)
-        run: sudo apt-get install libfmt-dev libpq-dev libsqlite3-dev
+        run: sudo apt-get install libfmt-dev libpq-dev libsqlite3-dev libmsgsl-dev
         if: matrix.os == 'ubuntu-22.04'
 
       - name: Configure CMake

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - mac-ci
   pull_request:
 
 jobs:
@@ -53,6 +54,28 @@ jobs:
 
       - name: Configure CMake
         run: CXX=${{ env.compiler }} cmake -B ${{ env.build_dir }} -S ${{ github.workspace }} -DPFR_ORM_ASAN:BOOL=ON -DPFR_ORM_TEST:BOOL=ON
+
+      - name: Build tests
+        run: cmake --build ${{ env.build_dir }}
+
+  test-gsl:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14
+    env:
+      build_dir: ${{ github.workspace }}/build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install fmt postgresql
+
+      - name: Configure CMake
+        run: CXX=${{ env.compiler }} cmake -B ${{ env.build_dir }} -S ${{ github.workspace }} -DPFR_ORM_ASAN:BOOL=ON -DPFR_ORM_TEST:BOOL=ON -DPFR_ORM_USE_GSL_SPAN:BOOL=ON
 
       - name: Build tests
         run: cmake --build ${{ env.build_dir }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: brew install fmt postgresql
+        run: brew install fmt postgresql cpp-gsl
 
       - name: Configure CMake
         run: CXX=${{ env.compiler }} cmake -B ${{ env.build_dir }} -S ${{ github.workspace }} -DPFR_ORM_ASAN:BOOL=ON -DPFR_ORM_TEST:BOOL=ON -DPFR_ORM_USE_GSL_SPAN:BOOL=ON

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - mac-ci
   pull_request:
 
 jobs:


### PR DESCRIPTION
As mentioned in #11, `PFR_ORM_USE_GSL_SPAN` is required to build with MacOS SDK