### PR TITLE
Add aliases for library targets

### DIFF
--- a/components/databases/postgres/CMakeLists.txt
+++ b/components/databases/postgres/CMakeLists.txt
@@ -6,6 +6,8 @@ target_sources(podrm-postgres PRIVATE lib/connection.cpp lib/result.cpp
                                       lib/str.cpp)
 target_link_libraries(
   podrm-postgres
-  PUBLIC podrm-metadata
-  PRIVATE podrm-multilambda PostgreSQL::PostgreSQL fmt::fmt)
+  PUBLIC podrm::metadata
+  PRIVATE podrm::multilambda PostgreSQL::PostgreSQL fmt::fmt)
 target_include_directories(podrm-postgres PUBLIC include)
+
+add_library(podrm::postgres ALIAS podrm-postgres)

--- a/components/databases/sqlite/CMakeLists.txt
+++ b/components/databases/sqlite/CMakeLists.txt
@@ -6,9 +6,11 @@ target_sources(podrm-sqlite PRIVATE lib/connection.cpp lib/cursor.cpp
                                     lib/entry.cpp lib/result.cpp lib/row.cpp)
 target_link_libraries(
   podrm-sqlite
-  PUBLIC podrm-metadata
-  PRIVATE podrm-multilambda SQLite::SQLite3 fmt::fmt)
+  PUBLIC podrm::metadata
+  PRIVATE podrm::multilambda SQLite::SQLite3 fmt::fmt)
 target_include_directories(podrm-sqlite PUBLIC include)
+
+add_library(podrm::sqlite ALIAS podrm-sqlite)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/components/databases/sqlite/test/CMakeLists.txt
+++ b/components/databases/sqlite/test/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 find_package(Catch2 3 REQUIRED)
 
 add_executable(${PROJECT_NAME} test.cpp)
-target_link_libraries(${PROJECT_NAME} podrm-sqlite podrm-reflection fmt::fmt
+target_link_libraries(${PROJECT_NAME} podrm::sqlite podrm::reflection fmt::fmt
                       Catch2::Catch2WithMain)
 
 include(CTest)

--- a/components/metadata/CMakeLists.txt
+++ b/components/metadata/CMakeLists.txt
@@ -2,7 +2,9 @@ add_library(podrm-metadata INTERFACE)
 
 target_compile_features(podrm-metadata INTERFACE cxx_std_20)
 target_include_directories(podrm-metadata SYSTEM INTERFACE include)
-target_link_libraries(podrm-metadata INTERFACE podrm-span)
+target_link_libraries(podrm-metadata INTERFACE podrm::span)
+
+add_library(podrm::metadata ALIAS podrm-metadata)
 
 if(BUILD_TESTING)
   # add_subdirectory(test)

--- a/components/reflection/CMakeLists.txt
+++ b/components/reflection/CMakeLists.txt
@@ -4,8 +4,10 @@ add_subdirectory(vendor)
 
 target_compile_features(podrm-reflection INTERFACE cxx_std_20)
 target_include_directories(podrm-reflection SYSTEM INTERFACE include)
-target_link_libraries(podrm-reflection INTERFACE podrm-metadata podrm-span
+target_link_libraries(podrm-reflection INTERFACE podrm::metadata podrm::span
                                                  Boost::pfr)
+
+add_library(podrm::reflection ALIAS podrm-reflection)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/components/reflection/test/CMakeLists.txt
+++ b/components/reflection/test/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(Catch2 3 REQUIRED)
 
 add_executable(${PROJECT_NAME} nested.cpp relation.cpp self_relation.cpp
                                simple.cpp)
-target_link_libraries(${PROJECT_NAME} podrm-reflection Catch2::Catch2WithMain)
+target_link_libraries(${PROJECT_NAME} podrm::reflection Catch2::Catch2WithMain)
 
 include(CTest)
 include(Catch)

--- a/components/utils/multilambda/CMakeLists.txt
+++ b/components/utils/multilambda/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_library(podrm-multilambda INTERFACE)
 target_include_directories(podrm-multilambda INTERFACE SYSTEM include)
+
+add_library(podrm::multilambda ALIAS podrm-multilambda)

--- a/components/utils/span/CMakeLists.txt
+++ b/components/utils/span/CMakeLists.txt
@@ -7,3 +7,5 @@ if(PODRM_USE_GSL_SPAN)
   target_link_libraries(podrm-span INTERFACE Microsoft.GSL::GSL)
 endif()
 target_include_directories(podrm-span INTERFACE SYSTEM include)
+
+add_library(podrm::span ALIAS podrm-span)


### PR DESCRIPTION
Add `podrm::*` aliases for library targets

This will be important when the installation option is implemented